### PR TITLE
Landscape and RTL support

### DIFF
--- a/DrawerLayout/DrawerLayout.cs
+++ b/DrawerLayout/DrawerLayout.cs
@@ -1,7 +1,10 @@
-﻿using System;
+using System;
+using System.Diagnostics;
 using System.Linq;
 using Windows.Foundation;
+using Windows.Graphics.Display;
 using Windows.UI;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
@@ -31,14 +34,17 @@ namespace DrawerLayout
         private Grid _mainFragment;
         private Grid _shadowFragment;
 
+        private const int MinusMargin2 = -200;
+        private const int MinusMargin = 0;
+
         #endregion
 
         #region Dependency Properties
 
         public bool IsDrawerOpen
         {
-             get { return (bool)GetValue(IsDrawerOpenProperty); }
-             set { SetValue(IsDrawerOpenProperty, value); }
+            get { return (bool)GetValue(IsDrawerOpenProperty); }
+            set { SetValue(IsDrawerOpenProperty, value); }
         }
 
         public static readonly DependencyProperty IsDrawerOpenProperty = DependencyProperty.Register("IsDrawerOpen", typeof(bool), typeof(DrawerLayout), new PropertyMetadata(false));
@@ -60,7 +66,24 @@ namespace DrawerLayout
         {
             IsDrawerOpen = false;
         }
-   
+
+        public void ResizeDrawer()
+        {
+            var o = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Orientation;
+            if (o == ApplicationViewOrientation.Landscape)
+            {
+                _listFragment.Width = Window.Current.Bounds.Width / 2;
+                _listFragment.Margin = new Thickness(-200, 0, 0, 0);
+            }
+                
+            else
+            {
+                _listFragment.Margin = new Thickness(0, 0, 0, 0);
+                _listFragment.Width = (Window.Current.Bounds.Width / 3) * 2;
+            }
+                
+        }
+
         public void InitializeDrawerLayout()
         {
             if (Children == null) return;
@@ -89,10 +112,10 @@ namespace DrawerLayout
             // Render transform _listFragment
             _listFragment.HorizontalAlignment = HorizontalAlignment.Left;
             _listFragment.VerticalAlignment = VerticalAlignment.Stretch;
-            _listFragment.Width = (Window.Current.Bounds.Width/3)*2;
+            this.ResizeDrawer();
             if (_listFragment.Background == null) _listFragment.Background = new SolidColorBrush(Color.FromArgb(255, 255, 255, 255));
 
-            var animatedTranslateTransform = new TranslateTransform {X = -_listFragment.Width, Y = 0};
+            var animatedTranslateTransform = new TranslateTransform { X = -_listFragment.Width + MinusMargin2, Y = 0};
 
             _listFragment.RenderTransform = animatedTranslateTransform;
             _listFragment.RenderTransformOrigin = new Point(0.5, 0.5);
@@ -120,7 +143,7 @@ namespace DrawerLayout
             _fadeInStoryboard = new Storyboard();
 
             // New double animation
-            var doubleAnimation1 = new DoubleAnimation {Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)), To = 0};
+            var doubleAnimation1 = new DoubleAnimation { Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)), To = 0, EasingFunction = new ExponentialEase()};
 
             Storyboard.SetTarget(doubleAnimation1, _listFragment);
             Storyboard.SetTargetProperty(doubleAnimation1, TranslatePath.Path);
@@ -129,12 +152,12 @@ namespace DrawerLayout
             // New color animation for _shadowFragment
             var colorAnimation1 = new ColorAnimation
             {
-                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)),
+                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
                 To = Color.FromArgb(190, 0, 0, 0)
             };
 
             Storyboard.SetTarget(colorAnimation1, _shadowFragment);
-            Storyboard.SetTargetProperty(colorAnimation1,ColorPath.Path);
+            Storyboard.SetTargetProperty(colorAnimation1, ColorPath.Path);
             _fadeInStoryboard.Children.Add(colorAnimation1);
 
             // Create a new fadeOut animation storyboard
@@ -143,8 +166,9 @@ namespace DrawerLayout
             // New double animation
             var doubleAnimation2 = new DoubleAnimation
             {
-                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)),
-                To = -_listFragment.Width
+                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
+                To = -_listFragment.Width + MinusMargin2,
+                EasingFunction = new ExponentialEase()
             };
 
             Storyboard.SetTarget(doubleAnimation2, _listFragment);
@@ -154,7 +178,7 @@ namespace DrawerLayout
             // New color animation for _shadowFragment
             var colorAnimation2 = new ColorAnimation
             {
-                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)),
+                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
                 To = Color.FromArgb(0, 0, 0, 0)
             };
 
@@ -172,6 +196,7 @@ namespace DrawerLayout
         public void OpenDrawer()
         {
             if (_fadeInStoryboard == null || _mainFragment == null || _listFragment == null) return;
+            _listFragment.Margin = new Thickness(0, 0, 0, 0);
             _shadowFragment.Visibility = Visibility.Visible;
             _shadowFragment.IsHitTestVisible = true;
             _shadowFragment.Background = new SolidColorBrush(Color.FromArgb(MaxAlpha, 0, 0, 0));
@@ -184,6 +209,7 @@ namespace DrawerLayout
         public void CloseDrawer()
         {
             if (_fadeOutStoryboard == null || _mainFragment == null || _listFragment == null) return;
+            
             _fadeOutStoryboard.Begin();
             _fadeOutStoryboard.Completed += fadeOutStoryboard_Completed;
             IsDrawerOpen = false;
@@ -197,8 +223,9 @@ namespace DrawerLayout
 
             var doubleAnimation = new DoubleAnimation
             {
-                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)),
-                To = -_listFragment.Width
+                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
+                To = -_listFragment.Width + MinusMargin2,
+                EasingFunction = new ExponentialEase()
             };
 
             Storyboard.SetTarget(doubleAnimation, _listFragment);
@@ -207,7 +234,7 @@ namespace DrawerLayout
 
             var colorAnimation = new ColorAnimation
             {
-                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)),
+                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
                 To = Color.FromArgb(0, 0, 0, 0)
             };
 
@@ -222,7 +249,7 @@ namespace DrawerLayout
         {
             _shadowFragment.IsHitTestVisible = false;
             _shadowFragment.Visibility = Visibility.Collapsed;
-
+            _listFragment.Margin = new Thickness(MinusMargin, 0, 0, 0);
             this.IsDrawerOpen = false;
 
             // raise close event
@@ -240,7 +267,7 @@ namespace DrawerLayout
 
             var doubleAnimation = new DoubleAnimation
             {
-                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)),
+                Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
                 To = left
             };
 
@@ -248,7 +275,7 @@ namespace DrawerLayout
             Storyboard.SetTargetProperty(doubleAnimation, TranslatePath.Path);
             s.Children.Add(doubleAnimation);
 
-            var colorAnimation = new ColorAnimation { Duration = new Duration(new TimeSpan(0, 0, 0, 0, 200)), To = color };
+            var colorAnimation = new ColorAnimation { Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)), To = color };
 
             Storyboard.SetTarget(colorAnimation, _shadowFragment);
             Storyboard.SetTargetProperty(colorAnimation, ColorPath.Path);
@@ -290,6 +317,12 @@ namespace DrawerLayout
 
         private void listFragment_ManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
         {
+            var o = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Orientation;
+            if (o == ApplicationViewOrientation.Landscape && this.IsDrawerOpen == false)
+                return;
+
+            this.ResizeDrawer();
+
             var listWidth = _listFragment.Width;
             if (!(e.Position.X >= listWidth - 100) || !(e.Position.X < listWidth)) return;
             _listFragment.ManipulationDelta += listFragment_ManipulationDelta;
@@ -357,15 +390,20 @@ namespace DrawerLayout
 
         private void mainFragment_ManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
         {
+            var o = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Orientation;
+            if (o == ApplicationViewOrientation.Landscape) return;
             // If the user has the first touch on the left side of canvas, that means he's trying to swipe the drawer
             if (!(e.Position.X <= 40)) return;
-
+            this.ResizeDrawer();
             // Manipulation can be allowed
             _mainFragment.ManipulationDelta += mainFragment_ManipulationDelta;
             _mainFragment.ManipulationCompleted += mainFragment_ManipulationCompleted;
         }
         private void mainFragment_ManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
         {
+            var o = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Orientation;
+            if (o == ApplicationViewOrientation.Landscape) return;
+
             if (Math.Abs(e.Cumulative.Translation.X) < 0) return;
             if (e.Cumulative.Translation.X >= _listFragment.Width)
             {
@@ -379,6 +417,9 @@ namespace DrawerLayout
         }
         private void mainFragment_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
         {
+            var o = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Orientation;
+            if (o == ApplicationViewOrientation.Landscape) return;
+
             // Get left of _listFragment
             var transform = (TranslateTransform)_listFragment.RenderTransform;
             if (transform == null) return;

--- a/DrawerLayout/DrawerLayout.cs
+++ b/DrawerLayout/DrawerLayout.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Windows.Foundation;
 using Windows.Graphics.Display;
 using Windows.UI;
+using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -34,8 +35,7 @@ namespace DrawerLayout
         private Grid _mainFragment;
         private Grid _shadowFragment;
 
-        private const int MinusMargin2 = -200;
-        private const int MinusMargin = 0;
+        private const int MinusMargin = -200;
 
         #endregion
 
@@ -113,9 +113,12 @@ namespace DrawerLayout
             _listFragment.HorizontalAlignment = HorizontalAlignment.Left;
             _listFragment.VerticalAlignment = VerticalAlignment.Stretch;
             this.ResizeDrawer();
+
+            Window.Current.SizeChanged += CurrentOnSizeChanged;
+
             if (_listFragment.Background == null) _listFragment.Background = new SolidColorBrush(Color.FromArgb(255, 255, 255, 255));
 
-            var animatedTranslateTransform = new TranslateTransform { X = -_listFragment.Width + MinusMargin2, Y = 0};
+            var animatedTranslateTransform = new TranslateTransform { X = -_listFragment.Width + MinusMargin, Y = 0};
 
             _listFragment.RenderTransform = animatedTranslateTransform;
             _listFragment.RenderTransformOrigin = new Point(0.5, 0.5);
@@ -167,7 +170,7 @@ namespace DrawerLayout
             var doubleAnimation2 = new DoubleAnimation
             {
                 Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
-                To = -_listFragment.Width + MinusMargin2,
+                To = -_listFragment.Width + MinusMargin,
                 EasingFunction = new ExponentialEase()
             };
 
@@ -193,6 +196,15 @@ namespace DrawerLayout
             _listFragment.ManipulationStarted += listFragment_ManipulationStarted;
 
         }
+
+        private void CurrentOnSizeChanged(object sender, WindowSizeChangedEventArgs windowSizeChangedEventArgs)
+        {
+            this.ResizeDrawer();
+            var o = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Orientation;
+            if (o == ApplicationViewOrientation.Landscape)
+                this.CloseDrawer();
+        }
+
         public void OpenDrawer()
         {
             if (_fadeInStoryboard == null || _mainFragment == null || _listFragment == null) return;
@@ -224,7 +236,7 @@ namespace DrawerLayout
             var doubleAnimation = new DoubleAnimation
             {
                 Duration = new Duration(new TimeSpan(0, 0, 0, 0, 300)),
-                To = -_listFragment.Width + MinusMargin2,
+                To = -_listFragment.Width + MinusMargin,
                 EasingFunction = new ExponentialEase()
             };
 
@@ -249,7 +261,7 @@ namespace DrawerLayout
         {
             _shadowFragment.IsHitTestVisible = false;
             _shadowFragment.Visibility = Visibility.Collapsed;
-            _listFragment.Margin = new Thickness(MinusMargin, 0, 0, 0);
+            _listFragment.Margin = new Thickness(0, 0, 0, 0);
             this.IsDrawerOpen = false;
 
             // raise close event


### PR DESCRIPTION
- Added landscape support by hiding the drawer -200 pixels to the left
- Changed animation durations from 200ms to 300ms
- Animations are now eased out
- Drawer size is now determined by app orientation
- Swiping menu out while in landscape from the edge of the screen is now disabled to prevent showing both notification center and drawer menu simultaneously
- Added support for RightToLeft languages
